### PR TITLE
fix: use kustomization

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -161,7 +161,9 @@ runs:
               echo "Error: Failed to build Kubernetes manifests using kustomize."
               exit 1
             fi
-            git add all.yaml
+            echo "Creating kustomization.yaml"
+            echo -e "resources:\n- all.yaml" > kustomization.yaml
+            git add all.yaml kustomization.yaml
           fi
           cd $GITHUB_WORKSPACE
         done
@@ -205,7 +207,13 @@ runs:
         fi
 
         git rm -rf . --quiet
-        git stash pop
+        git stash apply || {
+          echo "Conflicts detected during stash apply. Overwriting with stashed files..."
+          # List all files in the stash and checkout each one, overwriting the existing files
+          git checkout stash -- $(git diff --name-only | tr '\n' ' ')
+          echo "All stashed files have been applied and overwritten existing files."
+        }
+
         git add **/all.yaml
 
         if ! git diff --quiet --staged; then


### PR DESCRIPTION
There is an interesting quirk of argocd where if your applications are of type directory then tools like argocd-image-updater won't work since they don't work with applications of type directory. This change is actually just taking the all.yaml and letting kustomize still 'be in control' so that tools like argocd-image-updater will still work